### PR TITLE
Update for dplyr 0.7.0

### DIFF
--- a/R/get-current-forecast.r
+++ b/R/get-current-forecast.r
@@ -81,7 +81,7 @@ get_current_forecast <- function(latitude, longitude,
 
     # convert times to POSIXct since they make sense in tbl_dfs/data.frames
 
-    ly <- dplyr::mutate_each_(dat, funs(convert_time), vars=ftimes[which(ftimes %in% colnames(dat))])
+    ly <- dplyr::mutate_at(dat, .funs=funs(convert_time), .vars=ftimes[which(ftimes %in% colnames(dat))])
 
   }) -> fio_data
 

--- a/R/get-forecast-for.r
+++ b/R/get-forecast-for.r
@@ -83,8 +83,8 @@ get_forecast_for <- function(latitude, longitude, timestamp,
 
     # convert times to POSIXct since they make sense in tbl_dfs/data.frames
 
-    ly <- dplyr::mutate_each_(dat, funs(convert_time),
-                              vars=ftimes[which(ftimes %in% colnames(dat))])
+    ly <- dplyr::mutate_at(dat, .funs= funs(convert_time),
+                              .vars=ftimes[which(ftimes %in% colnames(dat))])
 
   }) -> fio_data
 


### PR DESCRIPTION
Quick hack from `mutate_each_` to `mutate_at` to avoid deprecation notice under dplyr 0.7.0. Lightly tested `get_current_forecast` and `get_forecast_for`.